### PR TITLE
fix: Make config import absolute to not break

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -4,9 +4,8 @@ import logging
 import discord
 
 from src import log_setup
+from src.config import TOKEN
 from src.database import init_db, shutdown_db
-
-from .config import TOKEN
 
 log_setup.setup_logging(logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
For some reason, it worked like this in the docker build, but not locally on my PC. Now it does. Magic.

I always got an error about it being a relative import outside a package